### PR TITLE
Set up Cursor Cloud dev environment (AGENTS.md + startup script)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,70 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### What this repo is
+
+This is **not a single product**. It is a large learning/tutorial monorepo: a
+collection of ~60 independent sample projects grouped by technology under
+top-level folders (`angular/`, `express/`, `js/`, `knapsack/`, `mfe/`,
+`nextjs/`, `py/`, `python/`, `react/`, `rn/`, `vue/`). There is **no root
+`package.json`, workspace config, or orchestration** — `readme1.md` at the root
+is empty. Each subproject is self-contained and set up / run on its own.
+
+### Toolchain (already present on the VM)
+
+- Node.js v22 + npm 10 (npm is the package manager — every Node project has a
+  `package-lock.json`; use `npm install`, not yarn/pnpm).
+- Python 3.12 + pip (only used by `python/plotly-dash`).
+
+### How dependencies work (important)
+
+There is **no shared dependency install**. Install per project on demand from
+that project's directory, e.g.:
+
+```bash
+cd nextjs/routing && npm install       # any Node project
+cd python/plotly-dash && pip install -r requirements.txt
+```
+
+The startup update script only pre-installs the reference demo app
+(`nextjs/routing`) so at least one app is immediately runnable. When you work on
+a different subproject, run `npm install` in that project's folder yourself.
+
+### Reference demo app: `nextjs/routing`
+
+A Next.js 13 "events" app (pages router) that is verified to install, lint,
+build, and run on this VM. Standard scripts from its `package.json`:
+
+- `npm run dev` – dev server on port `3000`
+- `npm run lint`
+- `npm run build`
+
+### Running other projects (per-project standard commands)
+
+Use each project's own `package.json` scripts / README. Common patterns:
+
+- Angular (`angular/*`): `npm start` / `ng serve` → port `4200`
+- React CRA (`react/*`): `npm start` → port `3000`
+- Next.js (`nextjs/*`): `npm run dev` → port `3000`
+- Vue (`vue/*`): `npm run serve` → port `8080`
+- Express (`express/*`): `npm start` (usually TypeScript, compiled to `dist/`)
+
+### Non-obvious gotchas
+
+- Some backends read `process.env.PORT` **with no fallback** and will fail to
+  bind unless `PORT` is set (e.g. `express/natoursapi`,
+  `js/multiplayer-game-01/server`).
+- `express/natoursapi` requires **MongoDB** plus a `config.env` with
+  `DATABASE`, `DATABASE_PASSWORD`, `JWT_SECRET`, etc. No `.env`/`config.env` is
+  committed anywhere in the repo.
+- Multi-service projects must run several dev servers together to work
+  end-to-end: `mfe/project2` (container 8080 + marketing 8081 + auth 8082 +
+  dashboard 8083), `mfe/ecomm1` (container 8080 + products 8081 + cart 8082),
+  `js/react-socket` (server 3001 + client 3000), `js/multiplayer-game-01`
+  (server + client 3000), `react/testing2/sundaes-on-demand` (client +
+  `sundae-server`), `rn/donationapp` (+ `rn/donationapp-server`).
+- `python/plotly-dash/requirements.txt` pins very old (Python-2-era) versions
+  and will likely need version bumps to install on Python 3.12.
+- The many `bootstrap.js` files under `mfe/*` are Webpack Module Federation
+  entry points, **not** setup scripts.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

This repo is a large learning/tutorial monorepo of ~60 independent sample projects (Angular, React, Vue, Next.js, Express, MFE, React Native, Python) with **no root config or shared dependency install**. This PR documents how to set up and run projects in the Cursor Cloud environment, without modifying any project code.

## Changes

- Add `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering:
  - What the repo is (independent per-project setup, no shared manifest).
  - Available toolchain (Node v22 / npm 10 / Python 3.12).
  - Per-project dependency + run commands and default ports.
  - Non-obvious gotchas (services requiring `PORT`/MongoDB/env files, multi-service MFE/socket apps, old Python pins).

## Startup update script

Set (via the environment tool, not committed) to a minimal, idempotent command that pre-installs the reference demo app so at least one app is immediately runnable:

```
if [ -f nextjs/routing/package.json ]; then npm install --prefix nextjs/routing; fi
```

Per-project deps for other subprojects are installed on demand (documented in AGENTS.md).

## Verification (reference demo: `nextjs/routing`, Next.js 13 events app)

- `npm install` — succeeded
- `npm run lint` — no ESLint warnings or errors
- `npm run build` — clean production build (7 routes)
- `npm run dev` — dev server on port 3000; homepage, `/events`, and `/api/hello` all respond

Browsed the app end-to-end: homepage event cards → "Explore Event" detail page → "Browse All Events" list page.

[nextjs_routing_events_demo.mp4](https://cursor.com/agents/bc-f7b730dd-78d8-457d-9816-144450173a75/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnextjs_routing_events_demo.mp4)

[Event detail page](https://cursor.com/agents/bc-f7b730dd-78d8-457d-9816-144450173a75/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fevent_detail_page.webp)
[All events page](https://cursor.com/agents/bc-f7b730dd-78d8-457d-9816-144450173a75/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fall_events_page.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7b730dd-78d8-457d-9816-144450173a75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7b730dd-78d8-457d-9816-144450173a75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

